### PR TITLE
Add HPO quality validation for neurodevelopmental disorders

### DIFF
--- a/phenoscore/hpo_phenotype/calc_hpo_sim.py
+++ b/phenoscore/hpo_phenotype/calc_hpo_sim.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import os
 import urllib.request
 
+# constant value for check_hpo_quality. Derived from control cohort percentiles (n=2157)
+MIN_RESNIK_SUM_P15 = 17
 
 class SimScorer:
     def __init__(self, similarity_data_path, hpo_network_csv_path, name_to_id_json):
@@ -330,3 +332,35 @@ class SimScorer:
             )
 
         return hpo_similarity_builder.build_similarities(output_dir)
+    
+    def check_hpo_quality(self, hpo_terms):
+        """
+        Validate HPO quality:
+        - At least 1 valid HPO term
+        - Resnik self-similarity sum >= threshold
+        - At least 1 descendant of neurodevelopmental delay or intellectual disability
+        """
+        print("Input HPO:", hpo_terms)
+        
+        # Filter terms
+        filtered = self.filter_hpo_df(hpo_terms)
+        if not filtered:
+            raise ValueError("No valid HPO terms found for this patient.")
+
+        #Resnik self-similarity sum
+        total = sum(self._get_similarity(t, t) for t in filtered if t in self.valid_terms)  # voorkomt ValueError
+        
+        if total < MIN_RESNIK_SUM_P15:
+            raise ValueError("HPO content of insufficient quality to make a significant prediction")
+
+        #Neurodevelopmental / ID descendant check
+        neurodev = self._convert_hpo_to_int("HP:0012758")
+        intel_dis = self._convert_hpo_to_int("HP:0001249")
+
+        neurodev_desc = nx.descendants(self.hpo_network, neurodev) | {neurodev}
+        intel_dis_desc = nx.descendants(self.hpo_network, intel_dis) | {intel_dis}
+
+        if not any(t in neurodev_desc or t in intel_dis_desc for t in filtered):
+            raise ValueError("Insufficient HPO overlap with neurodevelopmental cohort")
+
+        return total

--- a/phenoscore/phenoscorer.py
+++ b/phenoscore/phenoscorer.py
@@ -20,13 +20,14 @@ from phenoscore.permutationtest.cross_validation import CrossValidatorAndLIME
 from phenoscore.permutationtest.permutation_test import PermutationTester
 from phenoscore.tables_and_figures.gen_tables_and_figs import get_top_hpo, get_heatmap_from_multiple
 
+from dataclasses import dataclass, field
+
 os.environ["MXNET_SUBGRAPH_VERBOSE"] = "0"
 conda_prefix = os.environ.get('CONDA_PREFIX')
 if conda_prefix is not None:
     os.environ['HOME'] = conda_prefix
 else:
     os.environ['HOME'] = os.getcwd()
-
 
 @dataclass
 class LIMEConfiguration:
@@ -42,7 +43,8 @@ class OptiLIMEConfiguration(LIMEConfiguration):
     """Specific configuration for OptiLIME"""
     optilime: bool = False
     maxrsquared: float = 0.9
-    kw_bounds: np.array = np.array([0.01, 5]).reshape(1, -1)
+    kw_bounds: np.array = field(default_factory=lambda: np.array([0.01, 5]).reshape(1, -1))
+
     n_iters: int = 100
     n_pre_samples: int = 30
 
@@ -414,9 +416,11 @@ class PhenoScorer:
                         self._simscorer, self.mode, None)
 
         if self.mode != 'face':
+            hpo_quality_controled = self._simscorer.check_hpo_quality(hpo_all_new_sample)
 
             filtered_hpo = self._simscorer.filter_hpo_df(hpo_all_new_sample)
             filtered_hpo = self._simscorer._convert_hpo_list(filtered_hpo)
+            
             if len(hpo_terms_pt) != len(hpo_terms_cont):
                 print(
                     "WARNING: Number of HPO terms for patients and controls is not equal.")

--- a/phenoscore/tests/test_hpo_quality.py
+++ b/phenoscore/tests/test_hpo_quality.py
@@ -1,0 +1,48 @@
+import unittest
+from phenoscore.phenoscorer import PhenoScorer
+
+
+class HPOQualityTester(unittest.TestCase):
+
+    def setUp(self):
+        ps = PhenoScorer("TEST", "hpo")
+        self.sim = ps._simscorer
+
+    def test_good_neurodevelopmental_hpo_set(self):
+        hpo_terms = [
+            'HP:0001263', 'HP:0002020', 'HP:0011968',
+            'HP:0002099', 'HP:0001631', 'HP:0001270', 'HP:0000750',
+            'HP:0002607', 'HP:0000486', 'HP:0031014', 'HP:0033454'
+        ]
+
+        result = self.sim.check_hpo_quality(hpo_terms)
+
+        self.assertIsInstance(result, (int, float))
+        self.assertGreater(result, 0)
+        print("Correct HPO set passed")
+
+    def test_insufficient_hpo_quality(self):
+        hpo_terms = [
+            'HP:0001263', 'HP:0012758', 'HP:0001270', 'HP:0000750',
+            'HP:0000718', 'HP:0001156', 'HP:0001182', 'HP:0030084'
+        ] 
+
+        with self.assertRaises(ValueError):
+            self.sim.check_hpo_quality(hpo_terms)
+        print("ValueError raised correctly")
+
+    def test_no_neurodevelopmental_overlap(self):
+        hpo_terms = [
+            'HP:0000325', 'HP:0000384', 'HP:0001508', 
+            'HP:0002575', 'HP:0000601', 'HP:0001537',
+            'HP:0040092', 'HP:0000218', 'HP:0001631',
+            'HP:0004691', 'HP:0009611', 'HP:0001643'
+            
+        ] 
+
+        with self.assertRaises(ValueError):
+            self.sim.check_hpo_quality(hpo_terms)
+        print("ValueError raised correctly")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: this PR adds a quality control step for the HPO content of VUS based analysis

Changes: 
- In Class SimScorer the method check_hpo_quality was created. This method filters the given HPO terms, then sums the Resnik scores of each term and compares the sum to a constant value representing the 15th percentile derived from a large control cohort
- In phenoscorer.py a line was added to predict_new_sample to initialize check_hpo_quality for a VUS in the 'hpo' or 'both' category
- test code was added to the folder tests called test_hpo_quality covering: valid neurodevelopmental profile - insufficient HPO quality  - absence of neurodevelopmental overlap

Testing
All new tests pass locally.
All additional code was tested using multiple representing hpo term sets